### PR TITLE
[Feature] Add DashboardNav and RecentWinners components 

### DIFF
--- a/lottix-app/src/components/DashboardAndRecentWinners.tsx
+++ b/lottix-app/src/components/DashboardAndRecentWinners.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// ========== Types ==========
+export type WinnerEntryProps = {
+  artist: string;
+  city: string;
+  winnerName: string;
+  winnerAnnounced: string; // ISO string
+};
+
+// ========== Utility ==========
+const getTimeAgo = (isoDate: string): string => {
+  const announced = new Date(isoDate);
+  const now = new Date();
+  const secondsAgo = Math.floor((now.getTime() - announced.getTime()) / 1000);
+  const hours = Math.floor(secondsAgo / 3600);
+  if (hours === 0) return 'Just now';
+  if (hours === 1) return '1 hour ago';
+  return `${hours} hours ago`;
+};
+
+// ========== Dashboard Nav ==========
+type DashboardNavProps = {
+    activeTab: string;
+    onTabChange: (tab: string) => void;
+  };
+  
+  const tabs = ['Active Entries', 'Winning History', 'Profile Settings', 'Notifications'];
+  
+   const DashboardNav: React.FC<DashboardNavProps> = ({ activeTab, onTabChange }) => {
+    return (
+      <NavWrapper>
+        <TabRow>
+          {tabs.map((tab) => (
+            <TabButton
+              key={tab}
+              active={activeTab === tab}
+              onClick={() => onTabChange(tab)}
+            >
+              {tab}
+            </TabButton>
+          ))}
+        </TabRow>
+      </NavWrapper>
+    );
+  };
+  
+
+// ========== Recent Winners ==========
+ const RecentWinners: React.FC<{ winners: WinnerEntryProps[] }> = ({ winners }) => {
+  return (
+    <Section>
+      <SubTitle>Recent Winners</SubTitle>
+      <WinnerRow>
+        {winners.map((w, i) => (
+          <WinnerCard key={i}>
+            <WinnerName>{w.winnerName} won</WinnerName>
+            <WinnerInfo>
+              {w.artist} - {w.city}
+            </WinnerInfo>
+            <WinnerTime>{getTimeAgo(w.winnerAnnounced)}</WinnerTime>
+          </WinnerCard>
+        ))}
+      </WinnerRow>
+    </Section>
+  );
+};
+
+// ========== Styled Components ==========
+const Section = styled.div`
+  margin-bottom: 32px;
+`;
+
+const NavWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 32px;
+`;
+
+const TabRow = styled.div`
+  display: flex;
+  gap: 32px;
+  justify-content: center;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 12px;
+`;
+
+const TabButton = styled.button<{ active: boolean }>`
+  font-family: 'Poppins', sans-serif;
+  font-size: 16px;
+  font-weight: ${({ active }) => (active ? '700' : '500')};
+  color: ${({ active }) => (active ? '#6610F2' : '#6B7280')};
+  background-color: ${({ active }) => (active ? 'rgba(102, 16, 242, 0.1)' : 'transparent')};
+  padding: 8px 16px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+`;
+
+const SubTitle = styled.h2`
+  font-family: 'Epilogue', sans-serif;
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 16px;
+`;
+
+
+
+const WinnerRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+`;
+
+const WinnerCard = styled.div`
+  background-color: #f9f9fb;
+  padding: 16px;
+  border-radius: 12px;
+  width: 200px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+`;
+
+const WinnerName = styled.p`
+  font-weight: 600;
+  font-size: 14px;
+  font-family: 'Poppins', sans-serif;
+`;
+
+const WinnerInfo = styled.p`
+  font-size: 14px;
+  font-family: 'Poppins', sans-serif;
+  margin-top: 4px;
+`;
+
+const WinnerTime = styled.p`
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 4px;
+  font-family: 'Poppins', sans-serif;
+`;
+
+// ========== Export Components ==========
+export { DashboardNav, RecentWinners };

--- a/lottix-app/src/data/concertData.ts
+++ b/lottix-app/src/data/concertData.ts
@@ -103,7 +103,7 @@ export const concertEvents: ConcertEvent[] = [
     maxEntries: 800,
     entriesSold: 705,
     lotteryDeadline: "2025-08-01T23:59:59Z",
-    lotteryWinner: "Pending"
+    lotteryWinner: "Alex Johnson"
   },
   {
     concertID: 5,

--- a/lottix-app/src/pages/UserDashboardPage.tsx
+++ b/lottix-app/src/pages/UserDashboardPage.tsx
@@ -16,7 +16,10 @@ const UserDashboardPage: React.FC = () => {
       city: event.city,
       winnerName: event.lotteryWinner,
       winnerAnnounced: event.lotteryDeadline,
-    }));
+    }))
+    .sort((a, b) => new Date(b.winnerAnnounced).getTime() - new Date(a.winnerAnnounced).getTime()) // sort descending (most recent first)
+    .slice(0, 3); // pick only the top 3
+    
 
   return (
     <div style={{ padding: '32px', maxWidth: '1200px', margin: '0 auto' }}>

--- a/lottix-app/src/pages/UserDashboardPage.tsx
+++ b/lottix-app/src/pages/UserDashboardPage.tsx
@@ -1,12 +1,84 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { DashboardNav, RecentWinners, WinnerEntryProps } from '../components/DashboardAndRecentWinners';
+// import ActiveLotteryEntries from '../components/ActiveLotteryEntries'; // leave this commented for now
 
-const UserDashboardPage: React.FC = () =>{
-    return (
-        <div style={{ textAlign: "center", padding: "20px" }}>
+const UserDashboardPage: React.FC = () => {
+  const [activeTab, setActiveTab] = useState('Active Entries');
+
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+  };
+
+  const winners: WinnerEntryProps[] = [
+    {
+      artist: 'Taylor Swift',
+      city: 'NYC',
+      winnerName: 'Alex W.',
+      winnerAnnounced: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
+    },
+    {
+      artist: 'Bad Bunny',
+      city: 'Miami',
+      winnerName: 'Maria L.',
+      winnerAnnounced: new Date(Date.now() - 5 * 3600 * 1000).toISOString(),
+    },
+    {
+      artist: 'BTS',
+      city: 'LA',
+      winnerName: 'David K.',
+      winnerAnnounced: new Date(Date.now() - 8 * 3600 * 1000).toISOString(),
+    },
+  ];
+
+  return (
+    <div style={{ padding: '32px', maxWidth: '1200px', margin: '0 auto' }}>
+      {/* Intro Header */}
+      <div style={{ textAlign: 'center', marginBottom: '32px' }}>
         <h1>🎟️ User Dashboard Page 🎟️</h1>
         <p>Welcome to the User Dashboard page!</p>
       </div>
-    )
-}
+
+      {/* Tabs */}
+      <DashboardNav activeTab={activeTab} onTabChange={handleTabChange} />
+
+      {activeTab === 'Active Entries' && (
+        <div style={placeholderStyle}>
+            <h3>🎫 Your active lottery entries will appear here soon!</h3>
+        </div>
+      )}
+
+      {activeTab === 'Winning History' && (
+        <div style={placeholderStyle}>
+          <h3>🏆 Winning history coming soon!</h3>
+        </div>
+      )}
+
+      {activeTab === 'Profile Settings' && (
+        <div style={placeholderStyle}>
+          <h3>⚙️ Profile settings coming soon!</h3>
+        </div>
+      )}
+
+      {activeTab === 'Notifications' && (
+        <div style={placeholderStyle}>
+          <h3>🔔 Notifications coming soon!</h3>
+        </div>
+      )}
+
+      {/* Recent Winners */}
+      <RecentWinners winners={winners} />
+    </div>
+  );
+};
 
 export default UserDashboardPage;
+
+// Inline styles
+const placeholderStyle: React.CSSProperties = {
+  backgroundColor: '#F9F9FB',
+  padding: '32px',
+  borderRadius: '12px',
+  textAlign: 'center',
+  marginBottom: '32px',
+  boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.05)',
+};

--- a/lottix-app/src/pages/UserDashboardPage.tsx
+++ b/lottix-app/src/pages/UserDashboardPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { DashboardNav, RecentWinners, WinnerEntryProps } from '../components/DashboardAndRecentWinners';
-// import ActiveLotteryEntries from '../components/ActiveLotteryEntries'; // leave this commented for now
+import { concertEvents } from '../data/concertData'; // make sure this is imported
 
 const UserDashboardPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState('Active Entries');
@@ -9,26 +9,14 @@ const UserDashboardPage: React.FC = () => {
     setActiveTab(tab);
   };
 
-  const winners: WinnerEntryProps[] = [
-    {
-      artist: 'Taylor Swift',
-      city: 'NYC',
-      winnerName: 'Alex W.',
-      winnerAnnounced: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
-    },
-    {
-      artist: 'Bad Bunny',
-      city: 'Miami',
-      winnerName: 'Maria L.',
-      winnerAnnounced: new Date(Date.now() - 5 * 3600 * 1000).toISOString(),
-    },
-    {
-      artist: 'BTS',
-      city: 'LA',
-      winnerName: 'David K.',
-      winnerAnnounced: new Date(Date.now() - 8 * 3600 * 1000).toISOString(),
-    },
-  ];
+  const winners: WinnerEntryProps[] = concertEvents
+    .filter(event => event.lotteryWinner !== 'Pending')
+    .map(event => ({
+      artist: event.artistName,
+      city: event.city,
+      winnerName: event.lotteryWinner,
+      winnerAnnounced: event.lotteryDeadline,
+    }));
 
   return (
     <div style={{ padding: '32px', maxWidth: '1200px', margin: '0 auto' }}>


### PR DESCRIPTION
### Summary
Added two new components for the user dashboard view:
1. DashboardNav handles top-level tab switching (Active Entries, Winning History, etc.)  [Component Log](https://docs.google.com/document/d/17cbxDxff5NRnFqTsGqSzLK1heG2sr3zQ7PgFOSZyICo/edit?tab=t.av3cxf64r919)
2. RecentWinners displays a list of the 3 most recent raffle winners, dynamically showing how long ago each win was [Component Log](https://docs.google.com/document/d/17cbxDxff5NRnFqTsGqSzLK1heG2sr3zQ7PgFOSZyICo/edit?tab=t.otf2xldux5pr)
3. Updated the UserDashboardPage to integrate both components and support future expansion (e.g., placeholders for content per tab).
### Testing Steps
1. Run dev server
2. Navigate to User Dashboard page

### Linked Issues
Closes #35 #50 